### PR TITLE
Webサーバー用途のECSサービス & AutoScalingの追加

### DIFF
--- a/terraform/envs/development/variables.tf
+++ b/terraform/envs/development/variables.tf
@@ -79,13 +79,13 @@ variable "ecs_web" {
     deployment_minimum_healthy_percent = 100
     deployment_maximum_percent         = 200
     health_check_path                  = "/health_check"
-    # scale_out_by_cpu                   = 80
-    # scale_in_by_cpu                    = 30
-    # scale_out_by_memory                = 80
-    # scale_in_by_memory                 = 30
-    # max_capacity                       = 2
-    # min_capacity                       = 1
-    # certificate_arn                    = ""
+    scale_out_by_cpu                   = 80
+    scale_in_by_cpu                    = 30
+    scale_out_by_memory                = 80
+    scale_in_by_memory                 = 30
+    max_capacity                       = 2
+    min_capacity                       = 1
+    certificate_arn                    = ""
     deregistration_delay               = 0
   }
 }

--- a/terraform/envs/development/variables.tf
+++ b/terraform/envs/development/variables.tf
@@ -93,11 +93,11 @@ variable "ecs_web" {
 variable "server_secrets" {
   type = list
   default = [
-    "AWS_DEFAULT_REGION",
-    "AWS_SECRET_ACCESS_KEY",
     "RAILS_LOG_TO_STDOUT",
-    "RAILS_MAX_THREADS",
-    "SSM_AGENT_CODE",
-    "SSM_AGENT_ID"
+    "RAILS_MAX_THREADS"
+    # "AWS_DEFAULT_REGION",
+    # "AWS_SECRET_ACCESS_KEY",
+    # "SSM_AGENT_CODE",
+    # "SSM_AGENT_ID"
   ]
 }

--- a/terraform/envs/production/variables.tf
+++ b/terraform/envs/production/variables.tf
@@ -79,13 +79,13 @@ variable "ecs_web" {
     deployment_minimum_healthy_percent = 100
     deployment_maximum_percent         = 200
     health_check_path                  = "/health_check"
-    # scale_out_by_cpu                   = 80
-    # scale_in_by_cpu                    = 30
-    # scale_out_by_memory                = 80
-    # scale_in_by_memory                 = 30
-    # max_capacity                       = 2
-    # min_capacity                       = 1
-    # certificate_arn                    = ""
+    scale_out_by_cpu                   = 80
+    scale_in_by_cpu                    = 30
+    scale_out_by_memory                = 80
+    scale_in_by_memory                 = 30
+    max_capacity                       = 2
+    min_capacity                       = 1
+    certificate_arn                    = ""
     deregistration_delay               = 0
   }
 }

--- a/terraform/envs/production/variables.tf
+++ b/terraform/envs/production/variables.tf
@@ -93,11 +93,11 @@ variable "ecs_web" {
 variable "server_secrets" {
   type = list
   default = [
-    "AWS_DEFAULT_REGION",
-    "AWS_SECRET_ACCESS_KEY",
     "RAILS_LOG_TO_STDOUT",
-    "RAILS_MAX_THREADS",
-    "SSM_AGENT_CODE",
-    "SSM_AGENT_ID"
+    "RAILS_MAX_THREADS"
+    # "AWS_DEFAULT_REGION",
+    # "AWS_SECRET_ACCESS_KEY",
+    # "SSM_AGENT_CODE",
+    # "SSM_AGENT_ID"
   ]
 }

--- a/terraform/modules/app/ecs_alb.tf
+++ b/terraform/modules/app/ecs_alb.tf
@@ -1,0 +1,77 @@
+resource "aws_lb" "app_web" {
+  name               = "${var.environment}-app-web"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.vpc.security_group_elb.id]
+  subnets            = [var.vpc.subnet_public[0].id, var.vpc.subnet_public[2].id]
+
+  access_logs {
+    bucket  = "app-logs"
+    prefix  = "elb"
+    enabled = true
+  }
+
+  tags = {
+    "Name"        = "${var.environment}_app_web"
+    "Environment" = var.environment
+  }
+}
+
+resource "aws_lb_listener" "app_web_http" {
+  load_balancer_arn = aws_lb.app_web.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app_web.arn
+  }
+
+  # default_action {
+  #   type = "redirect"
+
+  #   redirect {
+  #     port        = 443
+  #     protocol    = "HTTPS"
+  #     status_code = "HTTP_301"
+  #   }
+  # }
+}
+
+# resource "aws_lb_listener" "app_web_https" {
+#   load_balancer_arn = aws_lb.app_web.arn
+#   port              = 443
+#   protocol          = "HTTPS"
+#   ssl_policy        = "ELBSecurityPolicy-2016-08"
+#   certificate_arn   = var.ecs.web.certificate_arn
+
+#   default_action {
+#     type             = "forward"
+#     target_group_arn = aws_lb_target_group.app_web.arn
+#   }
+# }
+
+resource "aws_lb_target_group" "app_web" {
+  name                 = "${var.environment}-app-web"
+  port                 = var.ecs.web.host_port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc.vpc.id
+  deregistration_delay = var.ecs.web.deregistration_delay
+  target_type          = "ip"
+
+  health_check {
+    interval            = 30
+    path                = var.ecs.web.health_check_path
+    port                = var.ecs.web.host_port
+    protocol            = "HTTP"
+    timeout             = 2
+    healthy_threshold   = 2
+    unhealthy_threshold = 10
+    matcher             = 200
+  }
+
+  tags = {
+    "Name"        = "${var.environment}_app_web"
+    "Environment" = var.environment
+  }
+}

--- a/terraform/modules/app/ecs_alb.tf
+++ b/terraform/modules/app/ecs_alb.tf
@@ -6,7 +6,7 @@ resource "aws_lb" "app_web" {
   subnets            = [var.vpc.subnet_public[0].id, var.vpc.subnet_public[2].id]
 
   access_logs {
-    bucket  = "app-logs"
+    bucket  = "samuraikun-ecs-sample-app-logs"
     prefix  = "elb"
     enabled = true
   }

--- a/terraform/modules/app/ecs_cloudwatch.tf
+++ b/terraform/modules/app/ecs_cloudwatch.tf
@@ -7,3 +7,75 @@ resource "aws_cloudwatch_log_group" "ecs_web" {
     Environment = var.environment
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "ecs_web_scale_out_cpu" {
+  alarm_name          = "${var.environment}_app_web_scale_out_cpu"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.ecs.web.scale_out_by_cpu
+  alarm_description   = "This metric monitors ecs cpu utilization for scale out"
+  alarm_actions       = [aws_appautoscaling_policy.app_web_scale_out[0].arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.app.name
+    ServiceName = aws_ecs_service.app_web.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_web_scale_in_cpu" {
+  alarm_name          = "${var.environment}_app_web_scale_in_cpu"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.ecs.web.scale_in_by_cpu
+  alarm_description   = "This metric monitors ecs cpu utilization for scale in"
+  alarm_actions       = [aws_appautoscaling_policy.app_web_scale_in[0].arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.app.name
+    ServiceName = aws_ecs_service.app_web.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_web_scale_out_memory" {
+  alarm_name          = "${var.environment}_app_web_scale_out_memory"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.ecs.web.scale_out_by_memory
+  alarm_description   = "This metric monitors ecs memory utilization for scale out"
+  alarm_actions       = [aws_appautoscaling_policy.app_web_scale_out[1].arn]
+
+  dimensions = {
+      ClusterName = aws_ecs_cluster.app.name
+      ServiceName = aws_ecs_service.app_web.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_web_scale_in_memory" {
+  alarm_name          = "${var.environment}_app_web_scale_in_memory"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = var.ecs.web.scale_in_by_memory
+  alarm_description   = "This metric monitors ecs memory utilization for scale in"
+  alarm_actions       = [aws_appautoscaling_policy.app_web_scale_in[1].arn]
+
+  dimensions = {
+      ClusterName = aws_ecs_cluster.app.name
+      ServiceName = aws_ecs_service.app_web.name
+  }
+}

--- a/terraform/modules/app/ecs_service.tf
+++ b/terraform/modules/app/ecs_service.tf
@@ -1,0 +1,113 @@
+resource "aws_service_discovery_private_dns_namespace" "app_web" {
+  name        = "${var.environment}_app_web"
+  description = "App Web Service in ${var.environment}"
+  vpc         = var.vpc.vpc.id
+}
+
+resource "aws_service_discovery_service" "app_web" {
+  name = "${var.environment}_app_web"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.app_web.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_ecs_service" "app_web" {
+  name                               = "${var.environment}_app_web_service"
+  cluster                            = aws_ecs_cluster.app.id
+  task_definition                    = aws_ecs_task_definition.app_web.arn
+  platform_version                   = "1.4.0"
+  desired_count                      = var.ecs.web.desired_count
+  launch_type                        = "FARGATE"
+  deployment_minimum_healthy_percent = var.ecs.web.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = var.ecs.web.deployment_maximum_percent
+  health_check_grace_period_seconds  = "120"
+
+  depends_on = [aws_lb.app_web]
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app_web.arn
+    container_name   = "web"
+    container_port   = var.ecs.web.host_port
+  }
+
+  network_configuration {
+    subnets          = var.vpc.subnet_private[*].id
+    security_groups  = [var.vpc.security_group_web.id]
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.app_web.arn
+  }
+
+  lifecycle {
+    ignore_changes = [
+      desired_count,
+      task_definition
+    ]
+  }
+}
+
+resource "aws_appautoscaling_target" "app_web_scale" {
+  service_namespace  = "ecs"
+  max_capacity       = var.ecs.web.max_capacity
+  min_capacity       = var.ecs.web.min_capacity
+  resource_id        = "service/${aws_ecs_cluster.app.name}/${aws_ecs_service.app_web.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+}
+
+locals {
+  metric_name = ["cpu", "memory"]
+}
+
+resource "aws_appautoscaling_policy" "app_web_scale_out" {
+  count              = length(local.metric_name)
+  name               = "${var.environment}_app_web_scale_out_${local.metric_name[count.index]}"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.app_web_scale.resource_id
+  scalable_dimension = aws_appautoscaling_target.app_web_scale.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.app_web_scale.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 300
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "app_web_scale_in" {
+  count              = length(local.metric_name)
+  name               = "${var.environment}_app_web_scale_in_${local.metric_name[count.index]}"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.app_web_scale.resource_id
+  scalable_dimension = aws_appautoscaling_target.app_web_scale.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.app_web_scale.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 300
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+}

--- a/terraform/modules/network/vpc_endpoint.tf
+++ b/terraform/modules/network/vpc_endpoint.tf
@@ -52,3 +52,16 @@ resource "aws_vpc_endpoint" "logs" {
     Name = "${var.terraform_environment}-endpoint-logs"
   }
 }
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id              = aws_vpc.app_network.id
+  service_name        = "com.amazonaws.ap-northeast-1.ssm"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.app_private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoint.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.terraform_environment}-endpoint-ssm"
+  }
+}


### PR DESCRIPTION
# Description

- Webサーバ用のServiceを追加
- ALBも追加
- オートスケールも追加

## 設定
#### サーバMinimum台数

|環境|台数|
|:---|:---|
|Staging|1台|
|Production|1台|

#### 1回デプロイの台数
- Staging、Production共に同じ設定

|Minimum|Maximum|
|:---|:---|
|100%|200%|

※ Webサーバが１台だと、デプロイ時に１台追加して、完了すると、１台削除。
Webサーバが２台なので、デプロイ時に２台追加して、完了すると、２台削除。

#### オートスケールの設定
- Staging、Production共に同じ設定

|項目|Scale out条件|Scale in条件|
|:---|:---|:---|
|CPU| 5分間Averageが80%以上で１台追加 | 5分間Averageが30%以下で１台削除 |
|Memory| 5分間Averageが80%以上で１台追加 | 5分間Averageが30%以下で１台削除 |